### PR TITLE
Fix tag indentation in `<void/>` example

### DIFF
--- a/src/modules/filters.haml
+++ b/src/modules/filters.haml
@@ -153,8 +153,8 @@
                         <regions>
                             <apply block="no-void" message="You may not edit the void area">
                                 <negative>
-                                 <rectangle min="-14,-12" max="15,13"/>
-                                 <region name="portals"/>
+                                    <rectangle min="-14,-12" max="15,13"/>
+                                    <region name="portals"/>
                                 </negative>
                             </apply>
                         </regions>


### PR DESCRIPTION
I just noticed this today, thought I would bring it up.
