### PR TITLE
Fix tag indentation inside the "Main map element"

### DIFF
--- a/src/modules/main.haml
+++ b/src/modules/main.haml
@@ -18,22 +18,22 @@
 
                         <?xml version="1.0"?>
                         <map proto="1.3.0">
-                        <name>Map Name</name> <!-- The maps name, shouldn't be too long -->
-                        <version>1.0</version> <!-- The map version -->
-                        <objective>Short description about the maps objective.</objective>
-
-                        <!-- Major map authors. -->
-                        <authors>
-                            <author>aPerson</author> <!-- The creator of the map -->
-                            <author contribution="Clarification of element usage, etc.">Plastix</author>
-                        </authors>
-
-                        <!-- People that contributed in some way to the map. -->
-                        <contributors>
-                            <contributor contribution="A contribution">aHelper</contributor>
-                        </contributors>
-
-                        <!-- Map modules, i.e. objectives, regions, spawns. -->
+                            <name>Map Name</name> <!-- The maps name, shouldn't be too long -->
+                            <version>1.0</version> <!-- The map version -->
+                            <objective>Short description about the maps objective.</objective>
+    
+                            <!-- Major map authors. -->
+                            <authors>
+                                <author>aPerson</author> <!-- The creator of the map -->
+                                <author contribution="Clarification of element usage, etc.">Plastix</author>
+                            </authors>
+    
+                            <!-- People that contributed in some way to the map. -->
+                            <contributors>
+                                <contributor contribution="A contribution">aHelper</contributor>
+                            </contributors>
+    
+                            <!-- Map modules, i.e. objectives, regions, spawns. -->
 
                         </map>
 


### PR DESCRIPTION
The elements inside `<map>` were on the same horizontal line as `<map>`. The proper syntax should have those elements one tab over.
