### PR TITLE
Spawns Can't be a block

### DIFF
--- a/src/modules/spawns.haml
+++ b/src/modules/spawns.haml
@@ -27,6 +27,8 @@
                     The default element specifies where observers and players without a team spawn. There should only be a single default spawn.  
                     `yaw=""` specifies what direction the player is looking horizontally from -180&deg; to 180&deg;. South 0&deg;, East -90&deg;, North 180&deg; and West 90&deg;.  
 
+                    `NOTE:` The spawn needs to be at least 2 blocks because PGM picks a random point for player spawns and if there is only one block it will error.  
+
                     `TIP:` You can copy the yaw from the F3 screen in minecraft.  
 
                     Multiple spawns from the same team can be grouped inside of a single `<spawns team="team name">` element. Spawn positions are picked randomly inside of the defined regions. The plugin will not validate the spawn position by default. Regions should be checked to make sure that they don't intersect with solid objects or are midair. Spawns can also be defined with the `safe="true"` attribute, PGM will then check that the player spawns on a solid object and not midair.


### PR DESCRIPTION
Added a note in the spawns module saying spawns need to be more than one block.
