### PR TITLE
Removed a negative sign that shouldn't be there

### DIFF
--- a/src/modules/regions.haml
+++ b/src/modules/regions.haml
@@ -38,7 +38,7 @@
 
                     `TIP:` Use the worldedit wand to help in defining region coordinates. Select an area and do `/size`, it will display two 3D coordinates. To use these coordinates you will have to take whichever X value is higher and add one to it, and then do the same for Y and Z. This is because PGM checks from the centre of blocks and WE checks from the corners. You don't have to do this for elements with just one coordinate such as: `<block>` or `<sphere>`.
 
-                    For example : `min="49,13,-4" max="37,10,4"` would become `min="50,14,-4" max="37,10,-5"`.
+                    For example : `min="49,13,-4" max="37,10,4"` would become `min="50,14,-4" max="37,10,5"`.
                     <!--![Regions](./images/selections.png)-->
 
                     <br/>


### PR DESCRIPTION
Removed a negative sign in the region example when adding 1 to the higher coordinates while using a world edit wand.

[19:28] Dinner1111: uhh yukon
[19:29] Dinner1111: why is the max of the example
[19:29] Dinner1111: a negative?
[19:29] YukonAppleGeek: Ya that should not be there
[19:29] Dinner1111: shouldnt that be a positive 5?
[19:29] Dinner1111: lol
[19:29] Dinner1111: ok
