### PR TITLE
Convert from `<block location=" "/>` to `<block> </block>`

### DIFF
--- a/src/examples/rfv3.haml
+++ b/src/examples/rfv3.haml
@@ -275,22 +275,22 @@
                     Specify a Capture the Wool type game, and the locations where the wools have to be placed by each team.
                         <wools>
                             <wool team="red" color="purple">
-                                <block location="-49,10,-91"/>
+                                <block>-49,10,-91</block>
                             </wool>
                             <wool team="red" color="yellow">
-                                <block location="49,10,-91"/>
+                                <block>49,10,-91</block>
                             </wool>
                             <wool team="red" color="cyan">
-                                <block location="0,16,-140"/>
+                                <block>0,16,-140</block>
                             </wool>
                             <wool team="blue" color="lime">
-                                <block location="49,10,91"/>
+                                <block>49,10,91</block>
                             </wool>
                             <wool team="blue" color="orange">
-                                <block location="-49,10,91"/>
+                                <block>-49,10,91</block>
                             </wool>
                             <wool team="blue" color="pink">
-                                <block location="0,16,140"/>
+                                <block>0,16,140</block>
                             </wool>
                         </wools>
                     


### PR DESCRIPTION
The [CTW Gamemode](http://docs.oc.tc/modules/gamemode_ctw) page tells you to use `<block>`, same with the [Regions](http://docs.oc.tc/modules/regions) page.

Found on the [RFV3](http://docs.oc.tc/examples/rfv3) example.
