### PR TITLE
Add info about the `result` attribute

### DIFF
--- a/src/modules/other_settings.haml
+++ b/src/modules/other_settings.haml
@@ -51,3 +51,8 @@
 
                         <multitrade/>
 
+                    <br/>
+                    Specify a time limit for any objective map. If the time runs out before the objective is completed, the match ends in a tie. `NOTE:` You can use [Time Formatters](/reference/formatting#time_formatters).
+
+                        <time result="objectives"/>1500</time>
+


### PR DESCRIPTION
Couldn't find it anywhere else, added it under Other Settings.
