### PR TITLE
Fix page shifting due to scrollbar

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -21,9 +21,8 @@
 }
 
 body { 
-    overflow:scroll; 
-    overflow-y:scroll;
-    overflow-x:hidden;
+    overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .jumbotron {


### PR DESCRIPTION
Page content is no longer affected by Y scrollbar, and X scrollbar will always be hidden now
