### PR TITLE
Clarify that kits overwrite items, but not empty inventories

### DIFF
--- a/src/modules/kits.haml
+++ b/src/modules/kits.haml
@@ -9,8 +9,7 @@
                 .page-header
                     %h1 Kits
                 :markdown
-                    Kits are used when spawning and in healing / special item zones. See [items](/modules/items) for information on how to give items or items with special properties, and [potion effects](/reference/potion_effects) for information on how to give potion effects. Kits can inherit items from other kits by using the `parents=""` attribute. Kits are referenced by their `name=""` from [spawns](/modules/spawns) and [regions](/modules/regions).
-
+                    Kits are used when spawning and in healing / special item zones. See [items](/modules/items) for information on how to give items or items with special properties, and [potion effects](/reference/potion_effects) for information on how to give potion effects. Kits can inherit items from other kits by using the `parents=""` attribute. Kits are referenced by their `name=""` from [spawns](/modules/spawns) and [regions](/modules/regions). Note that a kit will not empty a inventory, but rather overwrite the slots. If you want an empty slot, you can use air as the material. See [Babylon](https://maps.oc.tc/Babylon/map.xml) for an example on a complete empty inventory kit.
 
                         <kits>
                             <kit name="spawn">


### PR DESCRIPTION
This might be unclear to some users. I did my best on explaining that kits don't clear the inventory, but feel free to improve it.
