### PR TITLE
Change § to ` in Tutorials module, for consistency

### DIFF
--- a/src/modules/tutorial.haml
+++ b/src/modules/tutorial.haml
@@ -30,7 +30,7 @@
                         <tutorial>
                             <stage title="Capture the Wool">
                                 <message>
-                                    <line>§rThis map is a §a§lCapture the Wool §r(CTW) map</line>
+                                    <line>`rThis map is a `a`lCapture the Wool `r(CTW) map</line>
                                     <line>The objective is to grab the wool on the other team's side and return it to your base.</line>
                                 </message>
                                 <teleport>


### PR DESCRIPTION
Change the mentions of § to ` in the Tutorials module to match up with
examples in other modules (Such as "Items & Armor").
