### PR TITLE
Cleanup the revision linking

### DIFF
--- a/src/_layouts/default.haml
+++ b/src/_layouts/default.haml
@@ -60,5 +60,5 @@
                     %li.pull-right
                         - commit_long = `git rev-parse HEAD`
                         - commit_short = `git rev-parse --short HEAD`
-                        %a{:href => "http://github.com/OvercastNetwork/docs.oc.tc/commit/" + commit_long}
-                            Git rev: #{commit_short}
+                        %a{:href => "https://github.com/OvercastNetwork/docs.oc.tc/commit/" + commit_long}
+                            Current Revision: #{commit_short}


### PR DESCRIPTION
Change "Git rev" --> "Current Revision"

Use SSL for github
