### PR TITLE
allow/deny-break and allow/deny-place are not valid parent filters

### DIFF
--- a/src/modules/filters.haml
+++ b/src/modules/filters.haml
@@ -45,18 +45,6 @@
                                 %td Filter block breaking and placing.
                             %tr
                                 %td
-                                    %code allow-place
-                                %td
-                                    %code deny-place
-                                %td Filter block placing.
-                            %tr
-                                %td
-                                    %code allow-break
-                                %td
-                                    %code deny-break
-                                %td Filter block breaking.
-                            %tr
-                                %td
                                     %code allow-world
                                 %td
                                     %code deny-world


### PR DESCRIPTION
Instead of those non-working/existant filters, use the scopes: block-break="" and block-place=""
