### PR TITLE
Updating the example map proto

### DIFF
--- a/src/modules/includes.haml
+++ b/src/modules/includes.haml
@@ -20,7 +20,7 @@
                     Example
 
                         <?xml version="1.0"?>
-                        <map proto="1.3.0">
+                        <map proto="1.3.2">
 
                         <!-- Add kits, classes etc., here -->
 


### PR DESCRIPTION
The current map proto is 1.3.2. The example still showed 1.3.0

My IGN: matic0basle
