### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pull requests should have the following things:
 
 #### Previewing your changes
 
-1. Install ruby, ruby on rails and bundle
+1. Install ruby, ruby on rails and bundler
 2. Run `bundle install` from the source root.
 3. Run `staticmatic preview` or `bundle exec staticmatic preview`
 4. Load `localhost:4000` in your browser.


### PR DESCRIPTION
I believe bundler is supposed here since the bundle install command is on the next line so at it's current sate the readme is saying to bundle twice.
