### PR TITLE
document the default amount for kill rewards

### DIFF
--- a/src/modules/killreward.haml
+++ b/src/modules/killreward.haml
@@ -13,6 +13,8 @@
                     So far, the only reward available is an `<item>`.
 
                     `e.g.` This module can be used to give upgrades to players by giving them gold ingots. Then once they have collected enough ingots they can craft armor, etc.
+                    
+                    By default the kill reward defaults to the amount of `1`.
 
                     <br/>
                     Example


### PR DESCRIPTION
I have seen people defining a kill reward to 1 when there is no need to.
