### PR TITLE
Fix various DTC errors

### DIFF
--- a/src/modules/gamemode_dtc.haml
+++ b/src/modules/gamemode_dtc.haml
@@ -9,9 +9,7 @@
                 .page-header
                     %h1 Destroy the Core
                 :markdown
-                    Players have to locate and break the enemy teams core, usually an obsidian sphere filled with lava. The lava has to leak out a certain amount for the game to end. Teams can have more than one core and each core can be made out of different materials.
-
-                    By default cores automatically change from their base material to gold after 15 minutes and glass after 20. The materials attribute follows the system of Obsidian -> Gold, Gold -> Glass. However if you set the material to anything other than Obsidian, Gold or Glass, it will not cycle to another block type.  This behavior can be modified with the [monument modes](/modules/monument_modes) module.
+                    Players have to locate and break the enemy team's core, usually an obsidian sphere filled with lava. The lava has to leak down a certain distance for the core to be destroyed. Teams can have more than one core and each core can be made out of different materials.
 
                     ##### Core Attributes
                 .table-responsive
@@ -25,13 +23,13 @@
                             %tr
                                 %td
                                     %code leak="5"
-                                %td Distance the cores contents have to leak in blocks.
+                                %td Distance below the bottom of the core region that the lava must leak.
                                 %td
                                     %span.label.label-primary Number
                             %tr
                                 %td
                                     %code material="obsidian"
-                                %td The cores material, used to do automatic mode changes.
+                                %td The core casing material, used to detect breaks, and for mode changes.
                                 %td
                                     %a{:href => "http://jd.bukkit.org/apidocs/org/bukkit/Material.html"} Bukkit Material
                             %tr
@@ -44,7 +42,7 @@
                                 %td
                                     %code mode-changes=""
                                 %td
-                                    Specify if this core uses custom
+                                    Specify if this core uses
                                     = succeed "." do
                                         %a{:href => "/modules/monument_modes"} monument modes
                                 %td
@@ -53,7 +51,7 @@
                                 %td
                                     %code show="true"
                                 %td
-                                    Specify if the objective should be hidden from all visible locations to the player. These locations include chat, the boss bar, and the scoreboard.
+                                    Specify if the core should be hidden from all visible locations to the player. These locations include chat, the boss bar, and the scoreboard.
                                     %br
                                     %code NOTE:
                                     The objective will also not be logged to the Database and the player will not recieve any raindrops upon completion.
@@ -65,4 +63,4 @@
                             <core team="blue"><cuboid min="10,15,12" max="12,13,16"/></core>
                         </cores>
 
-                    Leak specifies how far the lava / water in the core has to leak out for the game to end. Whatever is inside of the core shouldn't be available anywhere else on the map, otherwise a core leak could be faked. This can be avoided by keeping the lava / water far away enough from the core and not giving players buckets or the ability to craft them.
+                    Lava should not be available anywhere else on the map, otherwise a core leak could be faked. This can be avoided by keeping the lava far away enough from the core and not giving players buckets or the ability to craft them.


### PR DESCRIPTION
- Remove default mode changes (there are none)
- Remove stuff about water cores (never existed)
- Clarify meaning of leak distance
- Grammar and wording fixes
