### PR TITLE
Clean up time limit section of other settings

### DIFF
--- a/src/modules/other_settings.haml
+++ b/src/modules/other_settings.haml
@@ -72,9 +72,7 @@
 
                     <br/>
                     #### Time Limit
-                    A time limit can be specified for all map types except [KoTH](/modules/gamemode_koth).
-
-                        <time result="objectives">1500</time>
-
                     The result attribute determines which team wins when the time runs out. It can be the name of a team, or one of the
                     special values "tie" for no winner, or "objectives" for the team that has the most objectives completed. The [time period](/reference/time_periods) format can be used to specify the time in minutes, etc.
+
+                        <time result="objectives">5m</time>


### PR DESCRIPTION
KotH is no longer limited to just `<limit>` so I removed the first statement. Also moved the XML example to below the description to match everything else on the Other Settings page.
