### PR TITLE
Remove documentation about overhead-color since it doesn't work now

### DIFF
--- a/src/modules/teams.haml
+++ b/src/modules/teams.haml
@@ -48,12 +48,6 @@
                                     %span.label.label-primary Number
                             %tr
                                 %td
-                                    %code overhead-color=""
-                                %td The color the text above each team members avatar is.
-                                %td
-                                    %a{:href => "/reference/formatting#chatColors"} Chat Color Name
-                            %tr
-                                %td
                                     %code respawn-limit=""
                                 %td The number of times a team may respawn before getting taken out of the match. Once met or exceeded, that team may not be joined, even by donors.
                                 %td


### PR DESCRIPTION
I've removed this from the teams module since it doesn't work anymore and is pretty much useless. 
