### PR TITLE
Fix completion attribute documentation

### DIFF
--- a/src/modules/gamemode_dtm.haml
+++ b/src/modules/gamemode_dtm.haml
@@ -48,7 +48,7 @@
                                     %a{:href => "/modules/teams"} Team Name
                             %tr
                                 %td
-                                    %code completion="100"
+                                    %code completion="100%"
                                 %td Percentage of the destroyable that needs to be destroyed for a win.
                                 %td
                                     %span.label.label-primary 0 - 100


### PR DESCRIPTION
The documentation for this attribute gives an example that the value this attribute accepts is `100` where it should be `100%`
