### PR TITLE
Italic should use o instead of i

### DIFF
--- a/src/reference/formatting.haml
+++ b/src/reference/formatting.haml
@@ -137,6 +137,6 @@
                     To have a line all italic and one word red you will have to to do the following.
 
                         <!-- Everything is italic and the word "italic" is also red -->
-                        <line>`oThis is a `citalic `r`itext with a single red word.</line>
+                        <line>`oThis is a `citalic `r`otext with a single red word.</line>
 
                     Copied from: [bukkit docs - Chat Color](http://jd.bukkit.org/doxygen/d7/dc0/enumorg_1_1bukkit_1_1ChatColor.html)


### PR DESCRIPTION
The documented style for Italic is using o as an example but bellow it is using i.

Testing in-game with bukkit does not work with i but does with o. Not sure if its the same on the Overcast servers.
