### PR TITLE
Change pre-made classes link

### DIFF
--- a/src/modules/includes.haml
+++ b/src/modules/includes.haml
@@ -56,3 +56,7 @@
                                 %td
                                     %a{:href => "https://maps.oc.tc/Blitz/GS/gs.xml"} gs.xml
                                 %td Contains pre-made classes for the Ghost Squadron gamemode
+                            %tr
+                                %td
+                                    %a{:href => "https://maps.oc.tc/Blitz/GS/gs-ffa.xml"} gs-ffa.xml
+                                %td Contains pre-made teams for the Ghost Squadron FFA gamemode


### PR DESCRIPTION
After the GS update the GS pre-made classes file was renamed. This PR fixes the link to that file.
