### PR TITLE
Update examples to use UUIDs for authors

### DIFF
--- a/src/examples/airship_battle.haml
+++ b/src/examples/airship_battle.haml
@@ -22,8 +22,7 @@
                         <objective>Leak lava from the enemy's obsidian core into the void.</objective>
                         <!-- States who made the map -->
                         <authors>
-                            <author uuid="30e27366-0b14-4076-8f55-0819ece49ce3"/>
-                            <!--  Dewtroid  -->
+                            <author uuid="30e27366-0b14-4076-8f55-0819ece49ce3"/> <!--  Dewtroid  -->
                         </authors>
                         <!-- Shows any map rules that are not in normal OCN rules -->
                         <rules>

--- a/src/examples/airship_battle.haml
+++ b/src/examples/airship_battle.haml
@@ -22,7 +22,8 @@
                         <objective>Leak lava from the enemy's obsidian core into the void.</objective>
                         <!-- States who made the map -->
                         <authors>
-                         <author>Dewtroid</author>
+                            <author uuid="30e27366-0b14-4076-8f55-0819ece49ce3"/>
+                            <!--  Dewtroid  -->
                         </authors>
                         <!-- Shows any map rules that are not in normal OCN rules -->
                         <rules>

--- a/src/examples/eldritch.haml
+++ b/src/examples/eldritch.haml
@@ -30,7 +30,8 @@
                     Specify the map author, there are no contributors.
 
                         <authors>
-                            <author>Vechs</author>
+                            <author uuid="1ac2b1d3-d623-4dab-99e5-08f3cfe1c1a0"/>
+                            <!-- Vechs1 -->
                         </authors>
 
                     <br/>

--- a/src/examples/eldritch.haml
+++ b/src/examples/eldritch.haml
@@ -30,8 +30,7 @@
                     Specify the map author, there are no contributors.
 
                         <authors>
-                            <author uuid="1ac2b1d3-d623-4dab-99e5-08f3cfe1c1a0"/>
-                            <!-- Vechs1 -->
+                            <author uuid="1ac2b1d3-d623-4dab-99e5-08f3cfe1c1a0"/> <!-- Vechs1 -->
                         </authors>
 
                     <br/>

--- a/src/examples/harb.haml
+++ b/src/examples/harb.haml
@@ -25,10 +25,8 @@
                     This map has 2 major authors specified and no contributors.
 
                         <authors>
-                            <author uuid="1379cb6e-f291-4498-9807-e636f9674ac0"/>
-                            <!--  SH4D0W_HAWK  -->
-                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/>
-                            <!--  Plastix  -->
+                            <author uuid="1379cb6e-f291-4498-9807-e636f9674ac0"/> <!--  SH4D0W_HAWK  -->
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/> <!--  Plastix  -->
                         </authors>
 
                     <br/>

--- a/src/examples/harb.haml
+++ b/src/examples/harb.haml
@@ -25,8 +25,10 @@
                     This map has 2 major authors specified and no contributors.
 
                         <authors>
-                            <author>SH4D0W_HAWK</author>
-                            <author>Plastix</author>
+                            <author uuid="1379cb6e-f291-4498-9807-e636f9674ac0"/>
+                            <!--  SH4D0W_HAWK  -->
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/>
+                            <!--  Plastix  -->
                         </authors>
 
                     <br/>

--- a/src/examples/rfv3.haml
+++ b/src/examples/rfv3.haml
@@ -22,14 +22,20 @@
                     Specify the maps authors and contributors. Each author and contributors `contribution=""` attribute is set to their specific contribution to the map.
 
                         <authors>
-                            <author contribution="map design and master gardener">MonsieurApple</author>
-                            <author contribution="map design and code memorization">Plastix</author>
-                            <author contribution="map design and beautification">IM_A_H0B0</author>
+                            <author uuid="3c7db14d-ac4b-4e35-b2c6-3b2237f382be" contribution="map design and master gardener"/>
+                            <!--  MonsieurApple  -->
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8" contribution="map design and code memorization"/>
+                            <!--  Plastix  -->
+                            <author uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="map design and beautification"/>
+                            <!--  IM_A_H0B0  -->
                         </authors>
                         <contributors>
-                            <contributor contribution="item management and shenanigan manager">Anxuiz</contributor>
-                            <contributor contribution="portals and various aesthetics">Torn_Ares</contributor>
-                            <contributor contribution="words">KasiCrafter</contributor>
+                            <contributor uuid="25961a08-c90c-4abd-b136-dad90e89c2eb" contribution="item management and shenanigan manager"/>
+                            <!--  Anxuiz  -->
+                            <contributor uuid="3a549b18-08ed-4756-a78c-b34d29a4fd87" contribution="portals and various aesthetics"/>
+                            <!--  Torn_Ares  -->
+                            <contributor uuid="4a0780d3-d9c4-41c4-a816-e077a36f27c9" contribution="words"/>
+                            <!--  KasiCrafter  -->
                         </contributors>
 
                     <br/>

--- a/src/examples/rfv3.haml
+++ b/src/examples/rfv3.haml
@@ -22,20 +22,14 @@
                     Specify the maps authors and contributors. Each author and contributors `contribution=""` attribute is set to their specific contribution to the map.
 
                         <authors>
-                            <author uuid="3c7db14d-ac4b-4e35-b2c6-3b2237f382be" contribution="map design and master gardener"/>
-                            <!--  MonsieurApple  -->
-                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8" contribution="map design and code memorization"/>
-                            <!--  Plastix  -->
-                            <author uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="map design and beautification"/>
-                            <!--  IM_A_H0B0  -->
+                            <author uuid="3c7db14d-ac4b-4e35-b2c6-3b2237f382be" contribution="map design and master gardener"/> <!--  MonsieurApple  -->
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8" contribution="map design and code memorization"/> <!--  Plastix  -->
+                            <author uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="map design and beautification"/> <!--  IM_A_H0B0  -->
                         </authors>
                         <contributors>
-                            <contributor uuid="25961a08-c90c-4abd-b136-dad90e89c2eb" contribution="item management and shenanigan manager"/>
-                            <!--  Anxuiz  -->
-                            <contributor uuid="3a549b18-08ed-4756-a78c-b34d29a4fd87" contribution="portals and various aesthetics"/>
-                            <!--  Torn_Ares  -->
-                            <contributor uuid="4a0780d3-d9c4-41c4-a816-e077a36f27c9" contribution="words"/>
-                            <!--  KasiCrafter  -->
+                            <contributor uuid="25961a08-c90c-4abd-b136-dad90e89c2eb" contribution="item management and shenanigan manager"/> <!--  Anxuiz  -->
+                            <contributor uuid="3a549b18-08ed-4756-a78c-b34d29a4fd87" contribution="portals and various aesthetics"/> <!--  Torn_Ares  -->
+                            <contributor uuid="4a0780d3-d9c4-41c4-a816-e077a36f27c9" contribution="words"/> <!--  KasiCrafter  -->
                         </contributors>
 
                     <br/>

--- a/src/examples/snowy_wars.haml
+++ b/src/examples/snowy_wars.haml
@@ -24,7 +24,8 @@
                         <!-- Specify the game objective and credit the creator of the map. -->
                         <objective>Break the obsidian from the enemy team's monument.</objective>
                         <authors>
-                            <author>roro28gutier</author>
+                            <author uuid="c14862ba-058a-44a2-a1c3-bfb0b462e198"/>
+                            <!--  roro28gutier  -->
                         </authors>
 
                     <br/>

--- a/src/examples/snowy_wars.haml
+++ b/src/examples/snowy_wars.haml
@@ -24,8 +24,7 @@
                         <!-- Specify the game objective and credit the creator of the map. -->
                         <objective>Break the obsidian from the enemy team's monument.</objective>
                         <authors>
-                            <author uuid="c14862ba-058a-44a2-a1c3-bfb0b462e198"/>
-                            <!--  roro28gutier  -->
+                            <author uuid="c14862ba-058a-44a2-a1c3-bfb0b462e198"/> <!--  roro28gutier  -->
                         </authors>
 
                     <br/>

--- a/src/examples/storm.haml
+++ b/src/examples/storm.haml
@@ -23,9 +23,12 @@
                     Specify map authors.
 
                         <authors>
-                            <author>Plastix</author>
-                            <author>Lyzak</author>
-                            <author>SajinZero</author>
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/>
+                            <!--  Plastix  -->
+                            <author uuid="5986da63-a546-49c5-812d-d5c41a42510a"/>
+                            <!--  Lyzak  -->
+                            <author uuid="90e029a3-6873-46a7-8430-0ec3dbc42aba"/>
+                            <!--  SajinZero  -->
                         </authors>
 
                     <br/>

--- a/src/examples/storm.haml
+++ b/src/examples/storm.haml
@@ -23,12 +23,9 @@
                     Specify map authors.
 
                         <authors>
-                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/>
-                            <!--  Plastix  -->
-                            <author uuid="5986da63-a546-49c5-812d-d5c41a42510a"/>
-                            <!--  Lyzak  -->
-                            <author uuid="90e029a3-6873-46a7-8430-0ec3dbc42aba"/>
-                            <!--  SajinZero  -->
+                            <author uuid="ef4ea031-998f-4ec9-b7b6-1bdd428bcef8"/> <!--  Plastix  -->
+                            <author uuid="5986da63-a546-49c5-812d-d5c41a42510a"/> <!--  Lyzak  -->
+                            <author uuid="90e029a3-6873-46a7-8430-0ec3dbc42aba"/> <!--  SajinZero  -->
                         </authors>
 
                     <br/>

--- a/src/examples/viridunblitz.haml
+++ b/src/examples/viridunblitz.haml
@@ -22,11 +22,14 @@
                     Specify the maps authors and contributors. Each author and contributors `contribution=""` attribute is set to their specific contribution to the map.
 
                         <authors>
-                            <author contribution="Map design and layout">OurLoneHero</author>
+                            <author uuid="27cf0cdd-c294-4163-a536-18e11360cc7b" contribution="Map design and layout"/>
+                            <!-- OurLoneHero -->
                         </authors>
                         <contributors>
-                            <contributor contribution="Map design, aesthetic changes, and XML">IM_A_H0B0</contributor>
-                            <contributor contribution="Design concepts and map design">ander301</contributor>
+                            <contributor uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="Map design, aesthetic changes, and XML"/>
+                            <!-- IM_A_H0B0 -->
+                            <contributor uuid="97abb45c-e545-473d-9b93-e1b9b94a43ee" contribution="Design concepts and map design"/>
+                            <!-- ander301 -->
                         </contributors>
 
                     <br/>

--- a/src/examples/viridunblitz.haml
+++ b/src/examples/viridunblitz.haml
@@ -22,14 +22,11 @@
                     Specify the maps authors and contributors. Each author and contributors `contribution=""` attribute is set to their specific contribution to the map.
 
                         <authors>
-                            <author uuid="27cf0cdd-c294-4163-a536-18e11360cc7b" contribution="Map design and layout"/>
-                            <!-- OurLoneHero -->
+                            <author uuid="27cf0cdd-c294-4163-a536-18e11360cc7b" contribution="Map design and layout"/> <!-- OurLoneHero -->
                         </authors>
                         <contributors>
-                            <contributor uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="Map design, aesthetic changes, and XML"/>
-                            <!-- IM_A_H0B0 -->
-                            <contributor uuid="97abb45c-e545-473d-9b93-e1b9b94a43ee" contribution="Design concepts and map design"/>
-                            <!-- ander301 -->
+                            <contributor uuid="82c796a5-c033-43be-af30-fa06496995f9" contribution="Map design, aesthetic changes, and XML"/> <!-- IM_A_H0B0 -->
+                            <contributor uuid="97abb45c-e545-473d-9b93-e1b9b94a43ee" contribution="Design concepts and map design"/> <!-- ander301 -->
                         </contributors>
 
                     <br/>


### PR DESCRIPTION
Update examples to use UUIDs for crediting authors and contributors. The UUIDs were copied from maps.oc.tc.

Also fixes spacing in airship battle example.