### PR TITLE
Change players to playerdata and modify the desc.

### DIFF
--- a/src/guides/packaging/cleaning_files.haml
+++ b/src/guides/packaging/cleaning_files.haml
@@ -60,10 +60,10 @@
                                 %td A timestamp when the level was last accessed
                             %tr
                                 %td
-                                    %code players/
+                                    %code playerdata/
                                 %td
                                     %span.label.label-danger NO
-                                %td Contains player.dat files which store the individual states of each player
+                                %td Contains files which store the individual states of each player
                             %tr
                                 %td
                                     %code data/villages.dat


### PR DESCRIPTION
Worlds created in 1.8 use the playerdata folder to store files for
individual states of each player based on their UUID unlike ones created
in 1.7.