### PR TITLE
New colour formatting and fix spelling error on Storm example

### DIFF
--- a/src/examples/storm.haml
+++ b/src/examples/storm.haml
@@ -37,7 +37,7 @@
                         <tutorial>
                             <stage title="King of the Hill">
                                 <message>
-                                    <line>§rThis map is a §a§lKill of the Hill §r(KotH) map</line>
+                                    <line>`rThis map is a `a`lKing of the Hill `r(KotH) map</line>
                                     <line>First team to hold all `a3 hills `rwins. You can also win by having the most hills `bcontrolled `rat the end of the time limit.</line>
                                 </message>
                                 <teleport>


### PR DESCRIPTION
Kill of the hill corrected to King of the hill
Add new text formatting (i.e. without §) to remove the contradiction as it is specificity said not to use this formatting.