### PR TITLE
Fix typo with coordinates being ordered incorrectly for cylinder regions

### DIFF
--- a/src/modules/regions.haml
+++ b/src/modules/regions.haml
@@ -53,7 +53,7 @@
                                     %pre
                                         %code= html_escape('<cylinder id="abc" base="X,Y,Z" radius="R" height="H"/>')
                                     %br
-                                    A cylinder located at <code>X,Z,Y</code> with a radius of <code>R</code> and a height of <code>H</code>.
+                                    A cylinder located at <code>X,Y,Z</code> with a radius of <code>R</code> and a height of <code>H</code>.
                                     %br
                                     %i Only block bounded when using a finite radius.
                                 %td.text-right


### PR DESCRIPTION
The coordinates for cylinder regions are ordered X,Z,Y; however, they should be ordered in the standard X,Y,Z format.