### PR TITLE
Removed inconsistent period

### DIFF
--- a/src/modules/lootables.haml
+++ b/src/modules/lootables.haml
@@ -195,7 +195,7 @@
                                 %td
                                     %code filter
                                 %td
-                                    Filter used to decide the eligibility of this option.
+                                    Filter used to decide the eligibility of this option
                                 %td
                                     %span.label.label-primary Filter
                                 %td


### PR DESCRIPTION
There was an unneeded period in the lootables reference.