### PR TITLE
Remove dead link to forums

### DIFF
--- a/src/_partials/guides_sidebar.haml
+++ b/src/_partials/guides_sidebar.haml
@@ -3,7 +3,6 @@
 - "XML Pointers",\
 - {"path" => "/guides/regions", "name" => "Defining Regions"},\
 - {"path" => "/guides/filter_apply_order", "name" => "Filter Apply Order"},\
-- {"path" => "https://oc.tc/forums/topics/5674a2ca5f35b90338000583", "name" => "XML Conventions", "icon" => "fa-comments"},\
 - "Packaging Maps",\
 - {"path" => "/guides/packaging/cleaning_files", "name" => "Cleaning Files"},\
 - {"path" => "/guides/packaging/pruning_chunks", "name" => "Pruning Chunks"},\


### PR DESCRIPTION
http://docs.oc.tc/guides/regions

![screenshot of sidebar](https://i.imgur.com/pGKhRfn.png)

When clicking the "XML Conventions" link, you're taken to the generic Rails error page:

![screenshot of error](https://i.imgur.com/2TMRBwb.png)

This pull requests removes the dead link from the sidebar.